### PR TITLE
Adding proper id's to the h3 tags in the markdown files

### DIFF
--- a/src/pages/terms_of_service.de.md
+++ b/src/pages/terms_of_service.de.md
@@ -2,7 +2,7 @@
 
 [Für Talente](#for-talents) & [Für Unternehmen](#for-employers)
 
-<h3 id="#for-talents">Für Talente</h3>
+<h3 id="for-talents">Für Talente</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Deutschland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Geschäftsführer: Kaya Taner, Emma Tracey, Umsatzsteuer-ID: DE300856850 (im Folgenden "Honeypot" oder "uns" ) betreibt eine Online-Job-Vermittlungsplattform unter https://www.honeypot.io/ und über andere Kanäle ("Service" ).
 Der Service verbindet Unternehmen ( "Unternehmen" ) und Kandidaten ("Talent" oder "Talente" ), um der passenden Person den passenden Job zu vermitteln.
@@ -150,7 +150,7 @@ Unternehmen sind natürliche Personen oder Geschäftseinheiten, die durch den Se
    7. Die englische Version dieser Servicebedingungen ist maßgebend.
    8. Durch die Einreichung eines Antrags auf Teilnahme am Service bestätigt das Talent, dass das Talent diese Servicebedingungen vollständig gelesen hat und erklärt sich damit einverstanden, an alle entsprechenden Bedingungen gebunden zu sein. Wenn das Talent nicht an diese Servicebedingungen gebunden sein möchte, sollte das Talent keinen Antrag auf Teilnahme am Service einreichen.
 
-<h3 id="#for-employers">Für Unternehmen</h3>
+<h3 id="for-employers">Für Unternehmen</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Deutschland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Geschäftsführer: Kaya Taner, Emma Tracey, Umsatzsteuer-ID: DE300856850 (im Folgenden "Honeypot" oder "uns" ) betreibt eine Online-Job Vermittlungsplattform unter https://www.honeypot.io/ und über andere Kanäle ("Service" ).
 Der Service verbindet Unternehmen ( "Unternehmen" ) und Kandidaten ("Talent" oder "Talente" ), um der passenden Person den passenden Job zu vermitteln.

--- a/src/pages/terms_of_service.de.md
+++ b/src/pages/terms_of_service.de.md
@@ -2,7 +2,7 @@
 
 [Für Talente](#for-talents) & [Für Unternehmen](#for-employers)
 
-### Für Talente
+<h3 id="#for-talents">Für Talente</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Deutschland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Geschäftsführer: Kaya Taner, Emma Tracey, Umsatzsteuer-ID: DE300856850 (im Folgenden "Honeypot" oder "uns" ) betreibt eine Online-Job-Vermittlungsplattform unter https://www.honeypot.io/ und über andere Kanäle ("Service" ).
 Der Service verbindet Unternehmen ( "Unternehmen" ) und Kandidaten ("Talent" oder "Talente" ), um der passenden Person den passenden Job zu vermitteln.
@@ -141,7 +141,7 @@ Unternehmen sind natürliche Personen oder Geschäftseinheiten, die durch den Se
    1. Diese Vereinbarung unterliegt deutschem Recht und ist entsprechend auszulegen. Wenn das Talent in der EU ansässig ist, darf ihm der durch das verbindliche Verbraucherschutzgesetz seines Wohnsitzlandes gebotene Schutz nicht entzogen werden. Sofern das Talent rechtliche Schritte einleitet, muss die Klage bei einem deutschen Gericht oder beim Gericht des Wohnsitzes des Talents eingereicht werden.
 
 1. **Allgemeine Bestimmungen**
-   1. Die Vereinbarung enthält die gesamte Vereinbarung zwischen Honeypot und dem Talent in Bezug auf den Gegenstand der Vereinbarung und ersetzt alle früheren oder gleichzeitigen schriftlichen oder mündlichen Vereinbarungen oder Absprachen. Geschäftsbedingungen des Talents werden nicht Bestandteil der Vereinbarung, es sei denn, Honeypot hat diese schriftlich akzeptiert.
+   1. Die Vereinbarung enthält die gesamte Vereinbarung zwischen Honeypot und dem Talent in Bezug auf den Gegenstand der Vereinbarung und ersetzt alle früheren oder gleichzeitigen schriftlichen oder mündlichen Vereinbarungen oder Absprachen. Geschäftsbedingungen des Talents werden nicht Bestandteil der Vereinbarung, es sei denn, Honeypot hat diese schriftgitlich akzeptiert.
    2. Alle Rechte und Pflichten von Honeypot im Rahmen der Vereinbarung können einem späteren Inhaber oder Betreiber des Service im Rahmen eines Zusammenschlusses, eines Erwerbs oder eines Verkaufs aller oder aller wesentlichen Vermögenswerte von Honeypot übertragen werden. Das Talent darf diese Vereinbarung oder einzelne oder sämtliche Rechte nicht ohne vorherige schriftliche Zustimmung von Honeypot abtreten oder übertragen. Diese Vereinbarung ist für die gesetzlichen Vertreter, Rechtsnachfolger und gültigen Bevollmächtigten der Parteien bindend.
    3. Vorbehaltlich der Bestimmungen in Ziff. 14 darf die Vereinbarung ohne vorherige schriftliche Zustimmung beider Parteien nicht geändert werden. Änderungen, Ergänzungen oder die Aufhebung der Vereinbarung (ganz oder teilweise) bedürfen der Schriftform (Brief, Fax oder E-Mail); auf das Erfordernis der Schriftform kann nur durch Schriftform verzichtet werden.
    4. Jede Partei der Vereinbarung ist gegenüber der anderen Partei ein unabhängiger Vertragspartner bezüglich aller Angelegenheiten, die sich aus dieser Vereinbarung ergeben. Nichts in dieser Vereinbarung soll so ausgelegt werden, dass eine Partnerschaft, ein Joint Venture, eine Vereinigung oder ein Arbeitsverhältnis zwischen den Parteien entsteht.
@@ -150,7 +150,7 @@ Unternehmen sind natürliche Personen oder Geschäftseinheiten, die durch den Se
    7. Die englische Version dieser Servicebedingungen ist maßgebend.
    8. Durch die Einreichung eines Antrags auf Teilnahme am Service bestätigt das Talent, dass das Talent diese Servicebedingungen vollständig gelesen hat und erklärt sich damit einverstanden, an alle entsprechenden Bedingungen gebunden zu sein. Wenn das Talent nicht an diese Servicebedingungen gebunden sein möchte, sollte das Talent keinen Antrag auf Teilnahme am Service einreichen.
 
-### Für Unternehmen
+<h3 id="#for-employers">Für Unternehmen</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Deutschland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Geschäftsführer: Kaya Taner, Emma Tracey, Umsatzsteuer-ID: DE300856850 (im Folgenden "Honeypot" oder "uns" ) betreibt eine Online-Job Vermittlungsplattform unter https://www.honeypot.io/ und über andere Kanäle ("Service" ).
 Der Service verbindet Unternehmen ( "Unternehmen" ) und Kandidaten ("Talent" oder "Talente" ), um der passenden Person den passenden Job zu vermitteln.

--- a/src/pages/terms_of_service.en.md
+++ b/src/pages/terms_of_service.en.md
@@ -2,7 +2,7 @@
 
 [For Talents](#for-talents) & [For Employers](#for-employers)
 
-### For Talents
+<h3 id="#for-talents">For Talents</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as "Honeypot" or "us" ) operates an online job marketplace platform via https://www.honeypot.io/ and other channels (the "Service" ).
 The Service connects companies ( "Company or "Companies" ), and candidates ( "Talent" or "Talents" ) with each other trying to match the right person with the right job.
@@ -149,7 +149,7 @@ Companies are natural persons or business entities searching for new employees o
    7. The English version of these Terms of Service is decisive.
    8. By submitting an application to join the Service, Talent affirms and acknowledges that Talent has read these Terms of Service in their entirety and agrees to be bound by all of its terms and conditions. If Talent does not wish to be bound by these Terms of Service, Talent should not submit an application to join the Service.
 
-### For Companies
+<h3 id="#for-employers">For Companies</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as “Honeypot” or “us” ) operates an online job marketplace platform via www.honeypot.io and other channels (the “Service” ).
 The Service connects companies ( “Company” or “Companies” ), and candidates ( “Talent” or “Talents” ) with each other trying to match the right person with the right job.

--- a/src/pages/terms_of_service.en.md
+++ b/src/pages/terms_of_service.en.md
@@ -149,7 +149,7 @@ Companies are natural persons or business entities searching for new employees o
    7. The English version of these Terms of Service is decisive.
    8. By submitting an application to join the Service, Talent affirms and acknowledges that Talent has read these Terms of Service in their entirety and agrees to be bound by all of its terms and conditions. If Talent does not wish to be bound by these Terms of Service, Talent should not submit an application to join the Service.
 
-<h3 id="for-employers">For Companies</h3>
+<h3 id="for-employers">For Employers</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as “Honeypot” or “us” ) operates an online job marketplace platform via www.honeypot.io and other channels (the “Service” ).
 The Service connects companies ( “Company” or “Companies” ), and candidates ( “Talent” or “Talents” ) with each other trying to match the right person with the right job.

--- a/src/pages/terms_of_service.en.md
+++ b/src/pages/terms_of_service.en.md
@@ -2,7 +2,7 @@
 
 [For Talents](#for-talents) & [For Employers](#for-employers)
 
-<h3 id="#for-talents">For Talents</h3>
+<h3 id="for-talents">For Talents</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as "Honeypot" or "us" ) operates an online job marketplace platform via https://www.honeypot.io/ and other channels (the "Service" ).
 The Service connects companies ( "Company or "Companies" ), and candidates ( "Talent" or "Talents" ) with each other trying to match the right person with the right job.
@@ -149,7 +149,7 @@ Companies are natural persons or business entities searching for new employees o
    7. The English version of these Terms of Service is decisive.
    8. By submitting an application to join the Service, Talent affirms and acknowledges that Talent has read these Terms of Service in their entirety and agrees to be bound by all of its terms and conditions. If Talent does not wish to be bound by these Terms of Service, Talent should not submit an application to join the Service.
 
-<h3 id="#for-employers">For Companies</h3>
+<h3 id="for-employers">For Companies</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as “Honeypot” or “us” ) operates an online job marketplace platform via www.honeypot.io and other channels (the “Service” ).
 The Service connects companies ( “Company” or “Companies” ), and candidates ( “Talent” or “Talents” ) with each other trying to match the right person with the right job.

--- a/src/pages/terms_of_service.md
+++ b/src/pages/terms_of_service.md
@@ -2,7 +2,7 @@
 
 [For Talents](#for-talents) & [For Employers](#for-employers)
 
-### For Talents
+<h3 id="#for-talents">For Talents</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as "Honeypot" or "us" ) operates an online job marketplace platform via https://www.honeypot.io/ and other channels (the "Service" ).
 The Service connects companies ( "Company or "Companies" ), and candidates ( "Talent" or "Talents" ) with each other trying to match the right person with the right job.
@@ -149,7 +149,7 @@ Companies are natural persons or business entities searching for new employees o
    7. The English version of these Terms of Service is decisive.
    8. By submitting an application to join the Service, Talent affirms and acknowledges that Talent has read these Terms of Service in their entirety and agrees to be bound by all of its terms and conditions. If Talent does not wish to be bound by these Terms of Service, Talent should not submit an application to join the Service.
 
-### For Companies
+<h3 id="#for-employers">For Companies</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as “Honeypot” or “us” ) operates an online job marketplace platform via www.honeypot.io and other channels (the “Service” ).
 The Service connects companies ( “Company” or “Companies” ), and candidates ( “Talent” or “Talents” ) with each other trying to match the right person with the right job.

--- a/src/pages/terms_of_service.md
+++ b/src/pages/terms_of_service.md
@@ -149,7 +149,7 @@ Companies are natural persons or business entities searching for new employees o
    7. The English version of these Terms of Service is decisive.
    8. By submitting an application to join the Service, Talent affirms and acknowledges that Talent has read these Terms of Service in their entirety and agrees to be bound by all of its terms and conditions. If Talent does not wish to be bound by these Terms of Service, Talent should not submit an application to join the Service.
 
-<h3 id="for-employers">For Companies</h3>
+<h3 id="for-employers">For Employers</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as “Honeypot” or “us” ) operates an online job marketplace platform via www.honeypot.io and other channels (the “Service” ).
 The Service connects companies ( “Company” or “Companies” ), and candidates ( “Talent” or “Talents” ) with each other trying to match the right person with the right job.

--- a/src/pages/terms_of_service.md
+++ b/src/pages/terms_of_service.md
@@ -2,7 +2,7 @@
 
 [For Talents](#for-talents) & [For Employers](#for-employers)
 
-<h3 id="#for-talents">For Talents</h3>
+<h3 id="for-talents">For Talents</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as "Honeypot" or "us" ) operates an online job marketplace platform via https://www.honeypot.io/ and other channels (the "Service" ).
 The Service connects companies ( "Company or "Companies" ), and candidates ( "Talent" or "Talents" ) with each other trying to match the right person with the right job.
@@ -149,7 +149,7 @@ Companies are natural persons or business entities searching for new employees o
    7. The English version of these Terms of Service is decisive.
    8. By submitting an application to join the Service, Talent affirms and acknowledges that Talent has read these Terms of Service in their entirety and agrees to be bound by all of its terms and conditions. If Talent does not wish to be bound by these Terms of Service, Talent should not submit an application to join the Service.
 
-<h3 id="#for-employers">For Companies</h3>
+<h3 id="for-employers">For Companies</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlin, Germany, Commercial Register: Amtsgericht Charlottenburg, HRB 167934 B, Managing Directors: Kaya Taner, Emma Tracey, VAT-ID: DE300856850 (hereinafter referred to as “Honeypot” or “us” ) operates an online job marketplace platform via www.honeypot.io and other channels (the “Service” ).
 The Service connects companies ( “Company” or “Companies” ), and candidates ( “Talent” or “Talents” ) with each other trying to match the right person with the right job.

--- a/src/pages/terms_of_service.nl.md
+++ b/src/pages/terms_of_service.nl.md
@@ -1,8 +1,8 @@
 ﻿## Terms of Service
 
-[Voor Talenten](#voor-talenten) & [Voor Bedrijven](#voor-bedrijven)
+[Voor Talenten](#for-talents) & [Voor Bedrijven](#for-employers)
 
-<h3 id="voor-talenten">Voor Talenten</h3>
+<h3 id="for-talents">Voor Talenten</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlijn, Duitsland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Algemeen Directeuren: Kaya Taner, Emma Tracey, BTW-nummer: DE300856850 (hierna aangeduid als "Honeypot" of "ons" ) is werkzaam als online arbeidsmarkt platform via https://www.honeypot.io/ en andere kanalen (de "Service" ).
 De Service verbindt bedrijven ( "Bedrijf” of "Bedrijven" ) en kandidaten ( "Talent" of "Talenten" ) met elkaar in een poging de juiste persoon te vinden voor de juiste baan.
@@ -149,7 +149,7 @@ Bedrijven zijn natuurlijke personen of bedrijfsentiteiten op zoek naar nieuwe we
    7. De Engelse versie van deze Servicevoorwaarden is doorslaggevend.
    8. Bij het indienen van een aanvraag om zich aan te sluiten bij de Service bevestigt en erkent Talent deze Servicevoorwaarden in zijn geheel te hebben gelezen en in te stemmen gebonden te zijn door alle voorwaarden. Indien Talent niet gebonden wil zijn door deze Servicevoorwaarden, dient Talent niet een aanvraag voor aansluiting bij de Service in te dienen.
 
-<h3 id="voor-bedrijven">Voor Bedrijven</h3>
+<h3 id="for-employers">Voor Bedrijven</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlijn, Duitsland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Algemeen Directeuren: Kaya Taner, Emma Tracey, BTW-nummer: DE300856850 (hierna aangeduid als "Honeypot" of "ons" ) is werkzaam als online arbeidsmarkt platform via https://www.honeypot.io/ en andere kanalen (de "Service" ).
 De Service verbindt bedrijven ( "Bedrijf” of "Bedrijven" ) en kandidaten ( "Talent" of "Talenten" ) met elkaar in een poging de juiste persoon te vinden voor de juiste baan.

--- a/src/pages/terms_of_service.nl.md
+++ b/src/pages/terms_of_service.nl.md
@@ -2,7 +2,7 @@
 
 [Voor Talenten](#voor-talenten) & [Voor Bedrijven](#voor-bedrijven)
 
-<h3 id="#voor-talenten">Voor Talenten</h3>
+<h3 id="voor-talenten">Voor Talenten</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlijn, Duitsland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Algemeen Directeuren: Kaya Taner, Emma Tracey, BTW-nummer: DE300856850 (hierna aangeduid als "Honeypot" of "ons" ) is werkzaam als online arbeidsmarkt platform via https://www.honeypot.io/ en andere kanalen (de "Service" ).
 De Service verbindt bedrijven ( "Bedrijf” of "Bedrijven" ) en kandidaten ( "Talent" of "Talenten" ) met elkaar in een poging de juiste persoon te vinden voor de juiste baan.
@@ -149,7 +149,7 @@ Bedrijven zijn natuurlijke personen of bedrijfsentiteiten op zoek naar nieuwe we
    7. De Engelse versie van deze Servicevoorwaarden is doorslaggevend.
    8. Bij het indienen van een aanvraag om zich aan te sluiten bij de Service bevestigt en erkent Talent deze Servicevoorwaarden in zijn geheel te hebben gelezen en in te stemmen gebonden te zijn door alle voorwaarden. Indien Talent niet gebonden wil zijn door deze Servicevoorwaarden, dient Talent niet een aanvraag voor aansluiting bij de Service in te dienen.
 
-<h3 id="#voor-bedrijven">Voor Bedrijven</h3>
+<h3 id="voor-bedrijven">Voor Bedrijven</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlijn, Duitsland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Algemeen Directeuren: Kaya Taner, Emma Tracey, BTW-nummer: DE300856850 (hierna aangeduid als "Honeypot" of "ons" ) is werkzaam als online arbeidsmarkt platform via https://www.honeypot.io/ en andere kanalen (de "Service" ).
 De Service verbindt bedrijven ( "Bedrijf” of "Bedrijven" ) en kandidaten ( "Talent" of "Talenten" ) met elkaar in een poging de juiste persoon te vinden voor de juiste baan.

--- a/src/pages/terms_of_service.nl.md
+++ b/src/pages/terms_of_service.nl.md
@@ -2,7 +2,7 @@
 
 [Voor Talenten](#voor-talenten) & [Voor Bedrijven](#voor-bedrijven)
 
-### Voor Talenten
+<h3 id="#voor-talenten">Voor Talenten</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlijn, Duitsland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Algemeen Directeuren: Kaya Taner, Emma Tracey, BTW-nummer: DE300856850 (hierna aangeduid als "Honeypot" of "ons" ) is werkzaam als online arbeidsmarkt platform via https://www.honeypot.io/ en andere kanalen (de "Service" ).
 De Service verbindt bedrijven ( "Bedrijf” of "Bedrijven" ) en kandidaten ( "Talent" of "Talenten" ) met elkaar in een poging de juiste persoon te vinden voor de juiste baan.
@@ -149,7 +149,7 @@ Bedrijven zijn natuurlijke personen of bedrijfsentiteiten op zoek naar nieuwe we
    7. De Engelse versie van deze Servicevoorwaarden is doorslaggevend.
    8. Bij het indienen van een aanvraag om zich aan te sluiten bij de Service bevestigt en erkent Talent deze Servicevoorwaarden in zijn geheel te hebben gelezen en in te stemmen gebonden te zijn door alle voorwaarden. Indien Talent niet gebonden wil zijn door deze Servicevoorwaarden, dient Talent niet een aanvraag voor aansluiting bij de Service in te dienen.
 
-### Voor Bedrijven
+<h3 id="#voor-bedrijven">Voor Bedrijven</h3>
 
 Honeypot GmbH, Schlesische Straße 26, 10997 Berlijn, Duitsland, Handelsregister: Amtsgericht Charlottenburg, HRB 167934 B, Algemeen Directeuren: Kaya Taner, Emma Tracey, BTW-nummer: DE300856850 (hierna aangeduid als "Honeypot" of "ons" ) is werkzaam als online arbeidsmarkt platform via https://www.honeypot.io/ en andere kanalen (de "Service" ).
 De Service verbindt bedrijven ( "Bedrijf” of "Bedrijven" ) en kandidaten ( "Talent" of "Talenten" ) met elkaar in een poging de juiste persoon te vinden voor de juiste baan.


### PR DESCRIPTION
There was no functionality behind the links on the TOS which is not that good for our clients to easily switch to their TOS.