### PR TITLE
Change the links to hive conference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 before_install:
   - rvm install 2.5.1
   - ruby --version
+  - gem install bundler -v 1.16.1
   - bundle --version
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 before_install:
   - rvm install 2.5.1
   - ruby --version
+  - bundle --version
 install:
   - npm install
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
-language: node_js
-node_js:
-  - 10.10.0
+language: scala
+scala:
+   2.11.2
+jdk:
+  - oraclejdk8
 before_cache:
   - rm -f ./node_modules/.bin/which # <-- workaround for https://github.com/travis-ci/travis-ci/issues/5092
 cache:
@@ -12,6 +14,7 @@ before_install:
   - ruby --version
   - gem install bundler -v 1.16.1
   - bundle --version
+  - java -version
 install:
   - npm install
   - bundle install

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -126,7 +126,7 @@ export default () => {
                   target="_blank"
                   rel="noopener
                   noreferrer"
-                  href={'https://hive.honeypot.io/hive-conference-2018/'}
+                  href={'https://hive.honeypot.io/'}
                 >
                   {t('hive-con')}
                 </a>

--- a/src/locales/community.json
+++ b/src/locales/community.json
@@ -16,7 +16,7 @@
       "2": {
         "headline": "Hive Conference",
         "text": "Hive is a conference for HR Leaders, Technical Hiring Managers, CTOs and VPs of Engineering focused on all aspects of building and scaling great engineering teams.",
-        "link": "https://hive.honeypot.io/hive-conference-2018/"
+        "link": "https://hive.honeypot.io/"
       },
       "3": {
         "headline": "Tech Talks & CTO Club",
@@ -86,7 +86,7 @@
       "2": {
         "headline": "Hive Conference",
         "text": "Hive ist eine Konferenz für HR Leader, technische Leiter, CTOs und alle anderen, die sich darauf fokussieren grossartige technische Team aufzubauen und zu skalieren.",
-        "link": "https://hive.honeypot.io/hive-conference-2018/"
+        "link": "https://hive.honeypot.io/"
       },
       "3": {
         "headline": "Tech Talks & CTO Club",
@@ -156,7 +156,7 @@
       "2": {
         "headline": "Hive Conference",
         "text": "Hive is een conferentie voor HR-leiders, Technical Hiring Managers, CTO's en VP's of Engineering die zich richten op alle aspecten van het bouwen en opschalen van top engineering teams.",
-        "link": "https://hive.honeypot.io/hive-conference-2018/"
+        "link": "https://hive.honeypot.io/"
       },
       "3": {
         "headline": "Tech Talks & CTO Club",


### PR DESCRIPTION
Swapping out the links for all languages in the community section, swapping out the link in the footer


cc @Kinghams22 

Fixes https://github.com/honeypotio/website/issues/60