### PR TITLE
Changing the date to look like september 20

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -66,7 +66,7 @@ export default ({ page, lang }) => {
           )) : null}
           <script>{
             `var DIGITAL_CLIMATE_STRIKE_OPTIONS = {
-              fullPageDisplayStartDate: new Date(2037, 1, 1) //forcing to not show
+              fullPageDisplayStartDate: new Date(2037, 8, 20) //forcing to not show
             };`
           }</script>
           <script src="https://assets.digitalclimatestrike.net/widget.js" async></script>


### PR DESCRIPTION
The banner takes the month and day information from the changed variable. Hence, changing the date to reflect the date of this year (without the year to avoid fullscreen)