### PR TITLE
Grab URL params and attaching them to signup link

### DIFF
--- a/src/components/header/navigation.js
+++ b/src/components/header/navigation.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { NamespacesConsumer } from 'react-i18next'
 import Link from 'gatsby-link'
 import extlinks from '../sign-up-links.json'
-import getCurrentPage, { getLinkTo } from '../../utils/page'
+import getCurrentPage, { getLinkTo, grabUrlParams} from '../../utils/page'
 
 //const links = ['index', 'tech-hiring', 'community', 'login']
 const links = [
@@ -33,6 +33,7 @@ export default class Navigation extends React.Component {
   componentDidMount() {
     if (typeof window !== 'undefined') {
       window.addEventListener('scroll', this.closeMenu)
+      grabUrlParams();
     }
   }
   componentWillUnmount() {
@@ -77,7 +78,7 @@ export default class Navigation extends React.Component {
               </li>
               <li className="header__link-item">
                 <a
-                  className="button button--primary header__link-item--button"
+                  className="button button--primary header__link-item--button js-signup"
                   rel="noopener
                   noreferrer"
                   href={this.props.page === 'tech-hiring' ? extlinks.tech_hiring : extlinks.index}

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -15,3 +15,8 @@ export function getLinkTo(page) {
   const prefix = lang ? lang + '/' : lang
   return prefix + page
 }
+
+export function grabUrlParams() {
+  const urlParams = window.location.search;
+  document.querySelector('.js-signup').href += urlParams;
+}


### PR DESCRIPTION
Adding a utility function to grab url params and attach them to the signup link

This is so marketing can use our website as a target for their campaigns, but the attribution is correctly making its way to the platform

